### PR TITLE
Support duplicate keys in urlencoded `@req`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ form data respectively. These fields are parsed as follows:
 - `query = {x::T}` or `form = {x::T}` is parsed as a query parameter named `x`
   which is parsed as a value of type `T` where `T` is any type that can be
   parsed from a `String` via `Base.parse`, the same as for `params` above.
+  If the parameter needs to contain multiple values, e.g. `a=1&a=2` then `T` can
+  be a `Vector` of the type of the individual values in which case the value of
+  `a` will be `["1", "2"]` when `Vector{String}` is specified.
 - any number of fields can be specified in the `{...}` syntax, separated by
   commas.
 - default values can be specified by using `x = default` instead of `x` in the

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,24 @@ function h_4(
 )
     return req
 end
+function h_5(
+    req::@req(
+        POST,
+        "/h/5/$(id::Int)",
+        form = {ids::Vector{Int} = Int[], values::Vector{String}, target},
+    ),
+)
+    return req
+end
+function h_6(
+    req::@req(
+        GET,
+        "/h/6/$(id::Int)",
+        query = {ids::Vector{Int} = Int[], values::Vector{String}, target},
+    ),
+)
+    return req
+end
 
 broken_1(req::@req GET "/broken/1/$id") = req.params.unknown
 broken_2(req::@req GET "/broken/2/$id") = req.query.unknown
@@ -254,6 +272,31 @@ end
         params = (;),
         query = (;),
         form = (; a = [1, 2], b = Dict("c" => 3, "d" => 4), c = Endpoints.CustomJSONType(0, "")),
+    )
+
+    test_wrapper(
+        req = HTTP.Request(
+            "POST",
+            "/h/5/123",
+            ["Content-Type" => "application/x-www-form-urlencoded"],
+            "ids=1&ids=2&values=a&values=b&target=123",
+        ),
+        f = Endpoints.h_5,
+        method = "POST",
+        target = "/h/5/123",
+        params = (; id = 123),
+        query = (;),
+        form = (; ids = [1, 2], values = ["a", "b"], target = "123"),
+    )
+
+    test_wrapper(
+        req = HTTP.Request("GET", "/h/6/123?ids=1&values=a&values=b&target=123"),
+        f = Endpoints.h_6,
+        method = "GET",
+        target = "/h/6/123?ids=1&values=a&values=b&target=123",
+        params = (; id = 123),
+        query = (; ids = Int[1], values = String["a", "b"], target = "123"),
+        form = (;),
     )
 
     # Ensure that running JET on these kinds of endpoints shows up the


### PR DESCRIPTION
So that `?a=1&a=2` can be parsed as `["1", "2"]` instead of dropping all but the last value.