### PR TITLE
fix: dev port, urlencoded parsing, Bonito drift, error page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# ReloadableMiddleware
+
+Julia HTTP middleware package providing hot-reloading dev server, routing, error handling, and docs.
+
+## Project Structure
+
+- `src/ReloadableMiddleware.jl` — main module, includes all submodules
+- `src/modules/` — submodules: Router, Server, Responses, Errors, Docs, Browser, Context, FileWatching, Reloader, Reviser, Extensions
+- `ext/` — package extensions for Bonito and Revise
+- `test/testsets/` — test files mirror module names
+
+## Development
+
+### Formatting
+
+Uses [Runic.jl](https://github.com/fredrikekre/Runic.jl) (zero-config formatter).
+
+```bash
+just format
+```
+
+### Testing
+
+```bash
+julia --project -e 'using Pkg; Pkg.test()'
+```
+
+### Conventions
+
+- Submodules are `include`d from `ReloadableMiddleware.jl`, not separate packages
+- HTTP.jl is the web framework foundation
+- `dev()` starts a hot-reloading dev server, `prod()` starts a production server
+- Run `just format` before every commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support `Vector{T}` fields in urlencoded body and query parsing for repeated keys [#44]
+
+### Fixed
+
+- Pass `port` kwarg to `HTTP.serve!` in `dev()` to match `prod()` behavior [#44]
+
 ### Changed
 
 - Moved documentation from `README.md` to a Documenter.jl build [#41]
@@ -131,3 +139,4 @@ Initial release.
 [#38]: https://github.com/MichaelHatherly/ReloadableMiddleware.jl/issues/38
 [#41]: https://github.com/MichaelHatherly/ReloadableMiddleware.jl/issues/41
 [#43]: https://github.com/MichaelHatherly/ReloadableMiddleware.jl/issues/43
+[#44]: https://github.com/MichaelHatherly/ReloadableMiddleware.jl/issues/44

--- a/ext/ReloadableMiddlewareBonitoExt.jl
+++ b/ext/ReloadableMiddlewareBonitoExt.jl
@@ -198,6 +198,7 @@ struct BonitoContext <: AbstractBonitoContext
 end
 
 Base.isopen(ws::WebSocketConnection{BonitoContext}) = Base.isopen(ws.handler)
+Base.write(ws::WebSocketConnection{BonitoContext}, sm::Bonito.SerializedMessage) = Base.write(ws.handler, Bonito.serialize_binary(sm))
 Base.write(ws::WebSocketConnection{BonitoContext}, binary) = Base.write(ws.handler, binary)
 Base.close(ws::WebSocketConnection{BonitoContext}) = Base.close(ws.handler)
 

--- a/ext/ReloadableMiddlewareBonitoExt.jl
+++ b/ext/ReloadableMiddlewareBonitoExt.jl
@@ -77,17 +77,16 @@ end
 # during the cleanup timer function. Doing it once at creation time rather than
 # later on appears to be cheaper.
 function _get_asset_session_id(asset::Bonito.BinaryAsset)
-    sm = Bonito.SerializedMessage(asset.data)
-    parts = Bonito.deserialize(sm)
-    info = get(parts, 1, nothing)
-    if isnothing(info)
-        @debug "empty message parts" asset
-        return nothing
-    else
-        data = Bonito.MsgPack.unpack(info.data)
-        session_id = get(data, 1, nothing)
-        return isa(session_id, AbstractString) ? session_id : nothing
+    try
+        ext = Bonito.MsgPack.unpack(asset.data)
+        if ext isa Bonito.MsgPack.Extension
+            parts = Bonito.MsgPack.unpack(ext.data)
+            session_id = get(parts, 1, nothing)
+            return isa(session_id, AbstractString) ? session_id : nothing
+        end
+    catch
     end
+    return nothing
 end
 _get_asset_session_id(::Bonito.AbstractAsset) = nothing
 

--- a/src/modules/Errors.jl
+++ b/src/modules/Errors.jl
@@ -232,7 +232,7 @@ function _process_stacktrace(error, bt)
                     if !StackTraces.is_top_level_frame(frame.sf)
                         file_name = frame.sf.file
                         line_number = frame.sf.line
-                        source_file = find_source(file_name)
+                        source_file = resolve_source_file(file_name)
                         func =
                             Base.isidentifier(frame.sf.func) ? String(frame.sf.func) :
                             "var\"$(frame.sf.func)\""
@@ -254,6 +254,8 @@ function find_source(file)
     file = replace(string(file), normpath(Sys.BUILD_STDLIB_PATH) => Sys.STDLIB; count = 1)
     return Base.find_source_file(file)
 end
+
+resolve_source_file(file) = something(find_source(file), string(file))
 
 function rewrite_path(path)
     fn(path, replacer) = replace(String(path), replacer; count = 1)

--- a/src/modules/Router.jl
+++ b/src/modules/Router.jl
@@ -573,22 +573,27 @@ end
 
 SymDict(dict) = Dict{Symbol, String}(Symbol(k) => v for (k, v) in dict)
 
-function _parse_pairs(pairs, type)
-    result = Dict{Symbol, Any}()
+_convert_field(::Type{T}, values::Vector{String}) where {T <: AbstractVector} =
+    StructTypes.constructfrom(T, values)
+_convert_field(::Type{Union{Nothing, T}}, values::Vector{String}) where {T <: AbstractVector} =
+    StructTypes.constructfrom(T, values)
+_convert_field(::Type{Union{Nothing, T}}, values::Vector{String}) where {T} =
+let v = only(values)
+    isempty(v) ? nothing : StructTypes.constructfrom(T, v)
+end
+_convert_field(::Type, values::Vector{String}) =
+    only(values)
+
+function _constructfrom_pairs(pairs, ::Type{T}) where {T}
+    grouped = Dict{Symbol, Vector{String}}()
     for (k, v) in pairs
-        sym = Symbol(k)
-        if haskey(result, sym)
-            existing = result[sym]
-            if existing isa Vector
-                push!(existing, v)
-            else
-                result[sym] = [existing, v]
-            end
-        else
-            result[sym] = fieldtype(type, sym) <: AbstractVector ? [v] : v
-        end
+        push!(get!(Vector{String}, grouped, Symbol(k)), v)
     end
-    return result
+    result = Dict{Symbol, Any}(
+        sym => _convert_field(fieldtype(T, sym), values)
+            for (sym, values) in grouped
+    )
+    return StructTypes.constructfrom(T, result)
 end
 
 function _path_parser(req, type)
@@ -598,14 +603,12 @@ end
 _path_parser(_, ::Nothing) = nothing
 
 function _query_parser(req, type)
-    queries = _parse_pairs(URIs.queryparampairs(URIs.URI(req.target).query), type)
-    return StructTypes.constructfrom(type, queries)
+    return _constructfrom_pairs(URIs.queryparampairs(URIs.URI(req.target).query), type)
 end
 _query_parser(_, ::Nothing) = nothing
 
 function _body_parser(req, type)
-    body = _parse_pairs(URIs.queryparampairs(String(req.body)), type)
-    return StructTypes.constructfrom(type, body)
+    return _constructfrom_pairs(URIs.queryparampairs(String(req.body)), type)
 end
 _body_parser(_, ::Nothing) = nothing
 
@@ -684,9 +687,7 @@ function _file_bytes_convert(::Type{T}, contenttype::String, bytes::Vector{UInt8
     if contenttype == "application/json"
         return JSON3.read(String(bytes), T; allow_inf = true)
     elseif contenttype == "application/x-www-form-urlencoded"
-        content = String(bytes)
-        params = _parse_pairs(URIs.queryparampairs(content), T)
-        return StructTypes.constructfrom(T, params)
+        return _constructfrom_pairs(URIs.queryparampairs(String(bytes)), T)
     else
         error("unsupported contenttype in multipart form data: $contenttype")
     end
@@ -712,9 +713,7 @@ function _multipart_convert(::Type{T}, wrapper::MultipartWrapper) where {T}
     elseif contenttype == "application/json"
         return JSON3.read(String(take!(wrapper.multipart.data)), T; allow_inf = true)
     elseif contenttype == "application/x-www-form-urlencoded"
-        content = String(take!(wrapper.multipart.data))
-        params = _parse_pairs(URIs.queryparampairs(content), T)
-        return StructTypes.constructfrom(T, params)
+        return _constructfrom_pairs(URIs.queryparampairs(String(take!(wrapper.multipart.data))), T)
     else
         error("unknown contenttype: $contenttype")
     end

--- a/src/modules/Router.jl
+++ b/src/modules/Router.jl
@@ -573,6 +573,24 @@ end
 
 SymDict(dict) = Dict{Symbol, String}(Symbol(k) => v for (k, v) in dict)
 
+function _parse_pairs(pairs, type)
+    result = Dict{Symbol, Any}()
+    for (k, v) in pairs
+        sym = Symbol(k)
+        if haskey(result, sym)
+            existing = result[sym]
+            if existing isa Vector
+                push!(existing, v)
+            else
+                result[sym] = [existing, v]
+            end
+        else
+            result[sym] = fieldtype(type, sym) <: AbstractVector ? [v] : v
+        end
+    end
+    return result
+end
+
 function _path_parser(req, type)
     params = SymDict(HTTP.getparams(req))
     return StructTypes.constructfrom(type, params)
@@ -580,13 +598,13 @@ end
 _path_parser(_, ::Nothing) = nothing
 
 function _query_parser(req, type)
-    queries = SymDict(URIs.queryparams(req))
+    queries = _parse_pairs(URIs.queryparampairs(URIs.URI(req.target).query), type)
     return StructTypes.constructfrom(type, queries)
 end
 _query_parser(_, ::Nothing) = nothing
 
 function _body_parser(req, type)
-    body = SymDict(URIs.queryparams(String(req.body)))
+    body = _parse_pairs(URIs.queryparampairs(String(req.body)), type)
     return StructTypes.constructfrom(type, body)
 end
 _body_parser(_, ::Nothing) = nothing
@@ -667,7 +685,7 @@ function _file_bytes_convert(::Type{T}, contenttype::String, bytes::Vector{UInt8
         return JSON3.read(String(bytes), T; allow_inf = true)
     elseif contenttype == "application/x-www-form-urlencoded"
         content = String(bytes)
-        params = SymDict(URIs.queryparams(content))
+        params = _parse_pairs(URIs.queryparampairs(content), T)
         return StructTypes.constructfrom(T, params)
     else
         error("unsupported contenttype in multipart form data: $contenttype")
@@ -695,7 +713,7 @@ function _multipart_convert(::Type{T}, wrapper::MultipartWrapper) where {T}
         return JSON3.read(String(take!(wrapper.multipart.data)), T; allow_inf = true)
     elseif contenttype == "application/x-www-form-urlencoded"
         content = String(take!(wrapper.multipart.data))
-        params = SymDict(URIs.queryparams(content))
+        params = _parse_pairs(URIs.queryparampairs(content), T)
         return StructTypes.constructfrom(T, params)
     else
         error("unknown contenttype: $contenttype")

--- a/src/modules/Server.jl
+++ b/src/modules/Server.jl
@@ -98,7 +98,7 @@ server_url(http_server) = "http://$(http_server.listener.hostname):$(http_server
 logging_format() = HTTP.logfmt"$time_iso8601 - $remote_addr:$remote_port - \"$request\" $status"
 
 """
-    dev(; router_modules, middleware, watch_file_types, docs, errors, kwargs...)
+    dev(; port = 8080, router_modules, middleware, watch_file_types, docs, errors, kwargs...)
 
 Start up a development server. Code revision via `Revise` integration is
 enabled if that package is loaded. The provided router modules reflect changes
@@ -126,6 +126,7 @@ Source links will navigate your editor to the specific file and line of the
 stacktrace.
 """
 function dev(;
+        port = 8080,
         router_modules = [],
         middleware = [],
         watch_file_types = (".jl",),
@@ -146,7 +147,7 @@ function dev(;
     ]
     handler = stream_handler(reduce(|>, reverse(middleware)))
 
-    http_server = HTTP.serve!(handler; access_log = logging_format(), kwargs..., stream = true)
+    http_server = HTTP.serve!(handler, port; access_log = logging_format(), kwargs..., stream = true)
 
     # Once the server is running check that the route works, and then open the
     # browser at that URL.

--- a/test/testsets/Errors.jl
+++ b/test/testsets/Errors.jl
@@ -32,4 +32,16 @@ import HTTP
     @test startswith(body, "<!DOCTYPE html>")
     @test contains(body, "Server Error")
     @test contains(body, "DivideError")
+
+    @testset "unresolvable source file" begin
+        fake_path = "reloadable-middleware-nonexistent-$(rand(UInt32)).jl"
+        @test Errors.find_source(fake_path) === nothing
+        @test Errors.resolve_source_file(fake_path) == fake_path
+        @test Errors.resolve_source_file(Symbol(fake_path)) == fake_path
+
+        # Sanity: a file that does resolve is returned verbatim by `find_source`.
+        real_path = @__FILE__
+        @test Errors.find_source(real_path) == real_path
+        @test Errors.resolve_source_file(real_path) == real_path
+    end
 end

--- a/test/testsets/Extensions.jl
+++ b/test/testsets/Extensions.jl
@@ -4,4 +4,14 @@ import ReloadableMiddleware.Extensions
 @testset "Extensions" begin
     bm = Extensions.bonito_middleware()
     @test isa(bm, Function)
+
+    @testset "BinaryAsset session id" begin
+        ext = Base.get_extension(ReloadableMiddleware, :ReloadableMiddlewareBonitoExt)
+        session = Bonito.Session(Bonito.NoConnection(); asset_server = Bonito.NoServer())
+        asset = Bonito.BinaryAsset(session, Dict(:payload => "hello"))
+        @test ext._get_asset_session_id(asset) == session.id
+
+        unrelated = Bonito.BinaryAsset(UInt8[0x00, 0x01, 0x02], "application/octet-stream")
+        @test ext._get_asset_session_id(unrelated) === nothing
+    end
 end

--- a/test/testsets/Router.jl
+++ b/test/testsets/Router.jl
@@ -94,6 +94,17 @@ module Routes
         return NoConvert(query.ids)
     end
 
+    @POST "/body-optional" function (req; body::@NamedTuple{name::Union{Nothing, String}})
+        return NoConvert(body.name)
+    end
+
+    @POST "/body-optional-vector" function (
+            req;
+            body::@NamedTuple{tags::Union{Nothing, Vector{String}}},
+        )
+        return NoConvert(body.tags)
+    end
+
     @STREAM "/stream" function (stream)
         #
     end
@@ -170,6 +181,22 @@ end
     @test router(HTTP.Request("POST", "/body-vector", [urlencoded], "ids=a")).value == ["a"]
     @test router(HTTP.Request("GET", "/query-vector?ids=a&ids=b")).value == ["a", "b"]
     @test router(HTTP.Request("GET", "/query-vector?ids=a")).value == ["a"]
+
+    @test router(HTTP.Request("POST", "/body-optional", [urlencoded], "name=alice")).value ==
+        "alice"
+    @test router(HTTP.Request("POST", "/body-optional", [urlencoded], "name=")).value === nothing
+    @test router(HTTP.Request("POST", "/body-optional", [urlencoded], "")).value === nothing
+
+    @test router(
+        HTTP.Request("POST", "/body-optional-vector", [urlencoded], "tags=a&tags=b"),
+    ).value == ["a", "b"]
+    @test router(HTTP.Request("POST", "/body-optional-vector", [urlencoded], "tags=a")).value ==
+        ["a"]
+    @test router(HTTP.Request("POST", "/body-optional-vector", [urlencoded], "")).value === nothing
+
+    @test_throws ArgumentError router(
+        HTTP.Request("POST", "/body-string", [urlencoded], "id=1&id=2"),
+    )
 
     @test router(HTTP.Request("PATCH", "/patch?id=1")).value == "1"
     @test router(HTTP.Request("DELETE", "/delete?id=1")).value == "1"

--- a/test/testsets/Router.jl
+++ b/test/testsets/Router.jl
@@ -86,6 +86,14 @@ module Routes
         return NoConvert(body.multipart.file)
     end
 
+    @POST "/body-vector" function (req; body::@NamedTuple{ids::Vector{String}})
+        return NoConvert(body.ids)
+    end
+
+    @GET "/query-vector" function (req; query::@NamedTuple{ids::Vector{String}})
+        return NoConvert(query.ids)
+    end
+
     @STREAM "/stream" function (stream)
         #
     end
@@ -156,6 +164,12 @@ end
     @test router(HTTP.Request("GET", "/query-enum?fruit=banana")).value == Routes.banana
     @test router(HTTP.Request("POST", "/body-enum", [urlencoded], "fruit=pineapple")).value ==
         Routes.pineapple
+
+    @test router(HTTP.Request("POST", "/body-vector", [urlencoded], "ids=a&ids=b&ids=c")).value ==
+        ["a", "b", "c"]
+    @test router(HTTP.Request("POST", "/body-vector", [urlencoded], "ids=a")).value == ["a"]
+    @test router(HTTP.Request("GET", "/query-vector?ids=a&ids=b")).value == ["a", "b"]
+    @test router(HTTP.Request("GET", "/query-vector?ids=a")).value == ["a"]
 
     @test router(HTTP.Request("PATCH", "/patch?id=1")).value == "1"
     @test router(HTTP.Request("DELETE", "/delete?id=1")).value == "1"


### PR DESCRIPTION
Grab-bag of small fixes on top of the initial dev-port + Vector parsing work.

- **`dev()` port** (d8f252d): Explicit `port = 8080` kwarg passed positionally to `HTTP.serve!`, mirroring `prod()`.
- **Router urlencoded parsing** (95f8926 + 1ea3217): Swap `URIs.queryparams` for `queryparampairs` and dispatch on field type via a new `_convert_field`. `Vector{T}` and `Union{Nothing, Vector{T}}` collect into a vector; `Union{Nothing, T}` scalars map empty strings to `nothing` (HTML checkbox semantics); duplicate keys against scalar fields now error via `only`. Covers body, query, and both multipart urlencoded paths.
- **Bonito ext drift** (72438b8, 90ed31a): `_get_asset_session_id` unpacks `MsgPack.Extension` directly — the old `SerializedMessage(data)` single-arg constructor no longer exists. Adds an explicit `Base.write(::WebSocketConnection{BonitoContext}, ::SerializedMessage)` method because our connection isn't a `FrontendConnection`, so Bonito's fallback didn't apply.
- **Error page** (2c02053): `resolve_source_file` falls back to the raw frame filename when `Base.find_source_file` returns `nothing`, preventing the literal string "nothing" from rendering.
- **AGENTS.md** (2c0a67c): Record the `just format` before every commit convention.