### PR TITLE
fix: emit one response when handlers stream SSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Emit exactly one HTTP response for handlers that stream their own response (server-sent events); closing the write side in `@STREAM` routes, the reloader, and `stream_handler` previously wrote a second response that desynchronized keep-alive connections [#51]
+
 ## [v3.0.0] - 2026-05-27
 
 ### Changed
@@ -151,3 +155,4 @@ Initial release.
 [#43]: https://github.com/MichaelHatherly/ReloadableMiddleware.jl/issues/43
 [#44]: https://github.com/MichaelHatherly/ReloadableMiddleware.jl/issues/44
 [#49]: https://github.com/MichaelHatherly/ReloadableMiddleware.jl/issues/49
+[#51]: https://github.com/MichaelHatherly/ReloadableMiddleware.jl/issues/51

--- a/src/modules/Reloader.jl
+++ b/src/modules/Reloader.jl
@@ -75,10 +75,10 @@ function reload(stream::HTTP.Stream, condition::Condition)
                 # Can fail if the user has reloaded their browser window
                 # manually. In that case, we just ignore the error.
                 @debug "failed to send reload event" error
-            finally
-                HTTP.closewrite(stream)
-                return HTTP.Response(200, "Stream complete.")
             end
+            # Leave the write side open; the server finalizes the stream after
+            # the handler returns.
+            return HTTP.Response(200, "Stream complete.")
         else
             return HTTP.Response(500, "Stream is no longer open.")
         end

--- a/src/modules/Router.jl
+++ b/src/modules/Router.jl
@@ -802,12 +802,10 @@ function _stream_handler(request::HTTP.Request, user_handler, request_parser)
     HTTP.setheader(stream, "Access-Control-Allow-Methods" => "GET")
     HTTP.setheader(stream, "Cache-Control" => "no-cache")
     HTTP.setheader(stream, "Content-Type" => "text/event-stream")
-    try
-        nt = request_parser(request)
-        return _invoke_kw(user_handler, stream, nt.path, nt.query, nt.body)
-    finally
-        HTTP.closewrite(stream)
-    end
+    # Leave the write side open; the server finalizes the stream after the
+    # handler returns. Closing it here causes a second response to be written.
+    nt = request_parser(request)
+    return _invoke_kw(user_handler, stream, nt.path, nt.query, nt.body)
 end
 
 # Websocket handler:

--- a/src/modules/Server.jl
+++ b/src/modules/Server.jl
@@ -42,13 +42,32 @@ end
 function stream_handler(middleware)
     return function (stream)
         ip, _ = Sockets.getpeername(stream)
-        handle_stream = HTTP.streamhandler(middleware |> decorate_request(; ip, stream))
+        handler = middleware |> decorate_request(; ip, stream)
         try
-            return handle_stream(stream)
+            return handle_stream(handler, stream)
         catch error
             return _intercept_epipe_error(error)
         end
     end
+end
+
+# Request handlers receive stream access via `request.context` and may write
+# the response themselves (server-sent events). When that happens the write
+# side is already started and the server finalizes the message after the
+# handler returns; writing `request.response` as well would emit a second
+# response on the connection, desynchronizing every later response on it.
+# Otherwise equivalent to `HTTP.streamhandler`.
+function handle_stream(handler, stream::HTTP.Stream)
+    request = stream.message
+    request.body = read(stream)
+    HTTP.closeread(stream)
+    request.response = handler(request)
+    request.response.request = request
+    if !HTTP.iswritable(stream)
+        HTTP.startwrite(stream)
+        write(stream, request.response.body)
+    end
+    return nothing
 end
 
 # Intermittant broken pipe errors seem to show up every now and then due to

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,4 +2,5 @@
 Bonito = "824d6782-a2ef-11e9-3a09-e5662e0c26f8"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,5 +8,6 @@ using Test
     include("testsets/Errors.jl")
     include("testsets/Responses.jl")
     include("testsets/Router.jl")
+    include("testsets/Server.jl")
     include("testsets/Extensions.jl")
 end

--- a/test/testsets/Server.jl
+++ b/test/testsets/Server.jl
@@ -1,0 +1,195 @@
+using ReloadableMiddleware
+using Revise
+using Test
+
+import HTTP
+import Sockets
+
+module ServerStreamRoutes
+
+    using ReloadableMiddleware.Router
+
+    import HTTP
+
+    @STREAM "/events" function (stream)
+        HTTP.startwrite(stream)
+        write(stream, "data: hello\n\n")
+        return ""
+    end
+
+end
+
+# A handler that streams its own response (SSE) must produce exactly one HTTP
+# response on the wire. Writing a second response, or injecting bytes after
+# the handler returns, desynchronizes every later response on a keep-alive
+# connection.
+@testset "Server" begin
+    # Collects raw bytes from the socket so assertions can inspect the exact
+    # wire format, including any spurious bytes after a response terminator.
+    function wire_reader(sock)
+        received = IOBuffer()
+        @async try
+            while !eof(sock)
+                write(received, readavailable(sock))
+            end
+        catch
+        end
+        return received
+    end
+
+    wire_bytes(received) = String(take!(copy(received)))
+
+    # Waits until the received bytes contain `n` chunked-body terminators,
+    # then a grace period so trailing spurious bytes get captured.
+    function await_responses(received, n; timeout = 60.0, grace = 0.5)
+        terminated = timedwait(timeout; pollint = 0.05) do
+            count("0\r\n\r\n", wire_bytes(received)) >= n
+        end
+        sleep(grace)
+        return terminated
+    end
+
+    function raw_get(sock, port, target)
+        write(
+            sock,
+            "GET $target HTTP/1.1\r\n" *
+                "Host: 127.0.0.1:$(port)\r\n" *
+                "Accept: text/event-stream\r\n\r\n",
+        )
+    end
+
+    function free_port()
+        srv = Sockets.listen(Sockets.localhost, 0)
+        port = Int(Sockets.getsockname(srv)[2])
+        close(srv)
+        return port
+    end
+
+    function assert_single_responses(received, n)
+        data = wire_bytes(received)
+        @test count("HTTP/1.1", data) == n
+        @test count("0\r\n\r\n", data) == n
+        @test endswith(data, "0\r\n\r\n")
+        return data
+    end
+
+    @testset "handler that streams its own response" begin
+        handler = function (request)
+            stream = request.context[:stream]::HTTP.Stream
+            HTTP.setheader(stream, "Content-Type" => "text/event-stream")
+            HTTP.startwrite(stream)
+            write(stream, "data: hello\n\n")
+            return request.response
+        end
+
+        port = free_port()
+        server = HTTP.serve!(
+            ReloadableMiddleware.Server.stream_handler(handler),
+            "127.0.0.1",
+            port;
+            stream = true,
+            verbose = -1,
+        )
+        sock = Sockets.connect("127.0.0.1", port)
+        try
+            received = wire_reader(sock)
+
+            raw_get(sock, port, "/events")
+            @test await_responses(received, 1) === :ok
+            data = assert_single_responses(received, 1)
+            @test contains(data, "data: hello")
+
+            # The connection must stay reusable and in sync.
+            raw_get(sock, port, "/events")
+            @test await_responses(received, 2) === :ok
+            assert_single_responses(received, 2)
+        finally
+            close(sock)
+            close(server)
+        end
+    end
+
+    @testset "handler that returns a plain response" begin
+        handler = function (request)
+            request.response.status = 200
+            request.response.body = "plain"
+            return request.response
+        end
+
+        port = free_port()
+        server = HTTP.serve!(
+            ReloadableMiddleware.Server.stream_handler(handler),
+            "127.0.0.1",
+            port;
+            stream = true,
+            verbose = -1,
+        )
+        try
+            response = HTTP.get("http://127.0.0.1:$(port)/")
+            @test response.status == 200
+            @test String(response.body) == "plain"
+        finally
+            close(server)
+        end
+    end
+
+    @testset "STREAM route" begin
+        router, _, _ = ReloadableMiddleware.Router.routes([ServerStreamRoutes])
+
+        port = free_port()
+        server = HTTP.serve!(
+            ReloadableMiddleware.Server.stream_handler(router),
+            "127.0.0.1",
+            port;
+            stream = true,
+            verbose = -1,
+        )
+        sock = Sockets.connect("127.0.0.1", port)
+        try
+            received = wire_reader(sock)
+
+            raw_get(sock, port, "/events")
+            @test await_responses(received, 1) === :ok
+            data = assert_single_responses(received, 1)
+            @test contains(data, "data: hello")
+        finally
+            close(sock)
+            close(server)
+        end
+    end
+
+    @testset "reloader stream" begin
+        handler = function (request)
+            stream = request.context[:stream]::HTTP.Stream
+            # `wait`/`notify` on `Base.Condition` must happen on one thread;
+            # `@async` keeps the notifier on the handler's thread.
+            condition = Base.Condition()
+            @async begin
+                sleep(0.2)
+                notify(condition)
+            end
+            return ReloadableMiddleware.Reloader.reload(stream, condition)
+        end
+
+        port = free_port()
+        server = HTTP.serve!(
+            ReloadableMiddleware.Server.stream_handler(handler),
+            "127.0.0.1",
+            port;
+            stream = true,
+            verbose = -1,
+        )
+        sock = Sockets.connect("127.0.0.1", port)
+        try
+            received = wire_reader(sock)
+
+            raw_get(sock, port, "/reload")
+            @test await_responses(received, 1) === :ok
+            data = assert_single_responses(received, 1)
+            @test contains(data, "data: reload")
+        finally
+            close(sock)
+            close(server)
+        end
+    end
+end


### PR DESCRIPTION
`HTTP.streamhandler` starts the response unconditionally after a
request handler returns, and `@STREAM` routes and the reloader closed
the stream's write side themselves. Both wrote a second response onto
the connection, desynchronizing every later keep-alive response:
clients received the previous request's body. Skip the post-return
write when the handler already started one, and leave the write side
open so the server finalizes the stream exactly once.

Wire-level regression tests assert a single status line and chunked
terminator per request on a reused connection.
